### PR TITLE
Alpha Animals: Fix patching AA_Bobeene

### DIFF
--- a/Alpha Animals/Alpha Animals_SK/1.3/Patches/HMCBiomesPatch.xml
+++ b/Alpha Animals/Alpha Animals_SK/1.3/Patches/HMCBiomesPatch.xml
@@ -29,14 +29,12 @@
                     </value>
                 </li>
                 <li Class="PatchOperationAdd">
-					<xpath>/Defs/ThingDef[defName="AA_Bobeene"]/race</xpath>
-					<value>
-                        <wildBiomes>
-                            <HmcIronWoodForest>0.01</HmcIronWoodForest>
-                            <HmcBambooGrove>0.03</HmcBambooGrove>
-						</wildBiomes>
-					</value>
-				</li>
+                    <xpath>/Defs/ThingDef[defName="AA_Bobeene"]/race/wildBiomes</xpath>
+                    <value>
+                        <HmcIronWoodForest>0.01</HmcIronWoodForest>
+                        <HmcBambooGrove>0.03</HmcBambooGrove>
+                    </value>
+                </li>
                 <li Class="PatchOperationAdd">
                     <xpath>/Defs/ThingDef[defName="AA_BedBug"]/race/wildBiomes</xpath>
                     <value>


### PR DESCRIPTION
Eliminate "`<wildBiomes>` duplicate note" error after launching the game.
"wildBiomes" node is added in `AlphaBiomesPatch.xml` so no need to add it twice.